### PR TITLE
Fix missing rename to "meitrex" causing build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ ARG DEPENDENCY=/workspace/app/build/dependency
 COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib
 COPY --from=build ${DEPENDENCY}/META-INF /app/META-INF
 COPY --from=build ${DEPENDENCY}/BOOT-INF/classes /app
-ENTRYPOINT ["java","-cp","app:app/lib/*","de.unistuttgart.iste.gits.reward.RewardServiceApplication"]
+ENTRYPOINT ["java","-cp","app:app/lib/*","de.unistuttgart.iste.meitrex.reward.RewardServiceApplication"]


### PR DESCRIPTION
Fix build failing because missed rename from "gits" to meitrex